### PR TITLE
Add Flask-based VPS reseller backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+SECRET_KEY=changeme
+DATABASE_URL=sqlite:///site.db
+MAIL_USERNAME=m.sakr@edafa.sa
+MAIL_PASSWORD=yourpassword
+MAIL_SERVER=smtp.edafa.sa
+MAIL_PORT=587
+CONTABO_CLIENT_ID=INT-12365842
+CONTABO_CLIENT_SECRET=yoursecret
+CONTABO_TOKEN_URL=https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# VPS Reseller Platform Backend
+
+This project provides a simple Flask-based backend to provision VPS servers via the Contabo API after PayPal payment. A basic user authentication flow, PayPal IPN endpoint, and email notifications are included.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Copy `.env.example` to `.env` and fill in the credentials.
+
+3. Run the application:
+
+```bash
+python run.py
+```
+
+## Endpoints
+
+- `POST /auth/register` – Register a new user with JSON `{"email": "...", "password": "..."}`
+- `POST /auth/login` – Log in a user
+- `GET /vps/plans` – List available VPS plans (requires login)
+- `POST /vps/create` – Provision a VPS after payment (requires login)
+- `GET /vps/` – List current user's VPS
+- `GET /vps/<id>` – Get details for a specific VPS
+- `POST /payments/ipn` – PayPal IPN endpoint
+- `GET /payments/invoices` – List user's invoices
+
+A Postman collection is provided in `postman_collection.json`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,34 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_bcrypt import Bcrypt
+from flask_login import LoginManager
+from flask_mail import Mail
+from .config import Config
+
+db = SQLAlchemy()
+bcrypt = Bcrypt()
+login_manager = LoginManager()
+mail = Mail()
+
+
+def create_app(config_class=Config):
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    db.init_app(app)
+    bcrypt.init_app(app)
+    login_manager.init_app(app)
+    mail.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+
+    from .routes.auth import auth_bp
+    from .routes.vps import vps_bp
+    from .routes.payments import payments_bp
+
+    app.register_blueprint(auth_bp, url_prefix='/auth')
+    app.register_blueprint(vps_bp, url_prefix='/vps')
+    app.register_blueprint(payments_bp, url_prefix='/payments')
+
+    return app

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,14 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+class Config:
+    SECRET_KEY = os.getenv('SECRET_KEY', 'changeme')
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///site.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    MAIL_SERVER = os.getenv('MAIL_SERVER', 'smtp.edafa.sa')
+    MAIL_PORT = int(os.getenv('MAIL_PORT', 587))
+    MAIL_USE_TLS = True
+    MAIL_USERNAME = os.getenv('MAIL_USERNAME')
+    MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')

--- a/app/contabo.py
+++ b/app/contabo.py
@@ -1,0 +1,49 @@
+import os
+import requests
+
+CONTABO_CLIENT_ID = os.getenv('CONTABO_CLIENT_ID')
+CONTABO_CLIENT_SECRET = os.getenv('CONTABO_CLIENT_SECRET')
+TOKEN_URL = os.getenv('CONTABO_TOKEN_URL', 'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token')
+API_BASE = 'https://api.contabo.com'
+
+class ContaboAPI:
+    def __init__(self):
+        self.token = None
+
+    def authenticate(self):
+        data = {
+            'client_id': CONTABO_CLIENT_ID,
+            'client_secret': CONTABO_CLIENT_SECRET,
+            'grant_type': 'client_credentials'
+        }
+        response = requests.post(TOKEN_URL, data=data)
+        response.raise_for_status()
+        self.token = response.json()['access_token']
+
+    def _headers(self):
+        if not self.token:
+            self.authenticate()
+        return {'Authorization': f'Bearer {self.token}'}
+
+    def list_plans(self):
+        url = f'{API_BASE}/vps/plans'
+        r = requests.get(url, headers=self._headers())
+        r.raise_for_status()
+        return r.json()
+
+    def create_vps(self, plan_id, region, os_id):
+        url = f'{API_BASE}/vps'
+        payload = {
+            'productId': plan_id,
+            'region': region,
+            'imageId': os_id
+        }
+        r = requests.post(url, json=payload, headers=self._headers())
+        r.raise_for_status()
+        return r.json()
+
+    def get_vps(self, vps_id):
+        url = f'{API_BASE}/vps/{vps_id}'
+        r = requests.get(url, headers=self._headers())
+        r.raise_for_status()
+        return r.json()

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1,0 +1,8 @@
+from flask_mail import Message
+from flask import current_app
+from . import mail
+
+def send_email(subject, recipients, body):
+    msg = Message(subject, recipients=recipients)
+    msg.body = body
+    mail.send(msg)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from . import db, bcrypt, login_manager
+from flask_login import UserMixin
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+class User(db.Model, UserMixin):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password = db.Column(db.String(60), nullable=False)
+    vps = db.relationship('VPS', backref='owner', lazy=True)
+
+    def set_password(self, password):
+        self.password = bcrypt.generate_password_hash(password).decode('utf-8')
+
+    def check_password(self, password):
+        return bcrypt.check_password_hash(self.password, password)
+
+class VPS(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    contabo_id = db.Column(db.String(64), unique=True, nullable=False)
+    plan = db.Column(db.String(100))
+    status = db.Column(db.String(50))
+    ip_address = db.Column(db.String(50))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+class Invoice(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    paypal_txn = db.Column(db.String(120), unique=True, nullable=False)
+    amount = db.Column(db.Float, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,32 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_user, logout_user, login_required
+from ..models import User
+from .. import db
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/register', methods=['POST'])
+def register():
+    data = request.json
+    if User.query.filter_by(email=data['email']).first():
+        return jsonify({'message': 'Email already registered'}), 400
+    user = User(email=data['email'])
+    user.set_password(data['password'])
+    db.session.add(user)
+    db.session.commit()
+    return jsonify({'message': 'User registered'})
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.json
+    user = User.query.filter_by(email=data['email']).first()
+    if user and user.check_password(data['password']):
+        login_user(user)
+        return jsonify({'message': 'Logged in'})
+    return jsonify({'message': 'Invalid credentials'}), 401
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return jsonify({'message': 'Logged out'})

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from ..models import Invoice
+from .. import db
+
+payments_bp = Blueprint('payments', __name__)
+
+@payments_bp.route('/ipn', methods=['POST'])
+def paypal_ipn():
+    data = request.form
+    txn_id = data.get('txn_id')
+    if Invoice.query.filter_by(paypal_txn=txn_id).first():
+        return 'OK'
+    invoice = Invoice(paypal_txn=txn_id, amount=float(data.get('mc_gross', 0)), user_id=1)
+    db.session.add(invoice)
+    db.session.commit()
+    return 'OK'
+
+@payments_bp.route('/invoices')
+@login_required
+def user_invoices():
+    invoices = Invoice.query.filter_by(user_id=current_user.id).all()
+    return jsonify([{'id': i.id, 'txn': i.paypal_txn, 'amount': i.amount} for i in invoices])

--- a/app/routes/vps.py
+++ b/app/routes/vps.py
@@ -1,0 +1,55 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_required, current_user
+from ..models import VPS
+from .. import db
+from ..contabo import ContaboAPI
+from ..email_utils import send_email
+
+vps_bp = Blueprint('vps', __name__)
+api = ContaboAPI()
+
+@vps_bp.route('/plans')
+@login_required
+def list_plans():
+    plans = api.list_plans()
+    return jsonify(plans)
+
+@vps_bp.route('/create', methods=['POST'])
+@login_required
+def create_vps():
+    data = request.json
+    result = api.create_vps(data['plan_id'], data['region'], data['os_id'])
+    vps = VPS(
+        contabo_id=result['id'],
+        plan=data.get('plan_name', ''),
+        status=result.get('status', ''),
+        ip_address=result.get('publicIp', ''),
+        owner=current_user
+    )
+    db.session.add(vps)
+    db.session.commit()
+    send_email('Your VPS is ready', [current_user.email], f"VPS ID: {vps.contabo_id}\nIP: {vps.ip_address}")
+    return jsonify({'message': 'VPS created', 'vps_id': vps.contabo_id})
+
+@vps_bp.route('/')
+@login_required
+def user_vps_list():
+    vps_list = [
+        {
+            'id': v.id,
+            'contabo_id': v.contabo_id,
+            'plan': v.plan,
+            'status': v.status,
+            'ip_address': v.ip_address,
+        } for v in current_user.vps
+    ]
+    return jsonify(vps_list)
+
+@vps_bp.route('/<int:vps_id>')
+@login_required
+def vps_detail(vps_id):
+    vps = VPS.query.get_or_404(vps_id)
+    if vps.owner != current_user:
+        return jsonify({'message': 'Forbidden'}), 403
+    info = api.get_vps(vps.contabo_id)
+    return jsonify(info)

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "name": "VPS Reseller API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Register",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"secret\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/auth/register",
+          "host": ["{{base_url}}"],
+          "path": ["auth", "register"]
+        }
+      }
+    },
+    {
+      "name": "Login",
+      "request": {
+        "method": "POST",
+        "header": [{"key": "Content-Type", "value": "application/json"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"secret\"\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/auth/login",
+          "host": ["{{base_url}}"],
+          "path": ["auth", "login"]
+        }
+      }
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+Flask-SQLAlchemy
+Flask-Login
+Flask-Bcrypt
+Flask-Mail
+python-dotenv
+requests

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement Flask backend scaffold with SQLAlchemy models
- add Contabo API integration and authentication routes
- provide email utility and PayPal IPN handler
- include README and Postman collection
- add environment example and requirements

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856a8a4bad883248d03727e57cbb701